### PR TITLE
Ordered sub-commander colours

### DIFF
--- a/ui/main/game/galactic_war/cards/gwc_minion.js
+++ b/ui/main/game/galactic_war/cards/gwc_minion.js
@@ -52,6 +52,9 @@ define([
       else if (inventory.minions)
         chance = chance / (inventory.minions().length + 1);
       var minion = _.sample(GWFactions[context.faction].minions);
+      // Select colour based on the amount of minions currently in the inventory.
+      // This ensures the best colours are picked first to avoid similar coloured commanders.
+      minion["color"] = GWFactions[context.faction].minion_colors[inventory.minions().length];
       return {
         params: {
           minion: minion,

--- a/ui/main/game/galactic_war/shared/js/gw_faction_0.js
+++ b/ui/main/game/galactic_war/shared/js/gw_faction_0.js
@@ -143,15 +143,81 @@ define(function () {
         },
       },
     ],
+    minion_colors: [
+      [
+        [204, 255, 255],
+        [192, 192, 192],
+      ],
+      [
+        [153, 255, 255],
+        [192, 192, 192],
+      ],
+      [
+        [102, 255, 255],
+        [192, 192, 192],
+      ],
+      [
+        [0, 255, 255],
+        [192, 192, 192],
+      ],
+      [
+        [0, 204, 204],
+        [192, 192, 192],
+      ],
+      [
+        [0, 153, 153],
+        [192, 192, 192],
+      ],
+      [
+        [153, 204, 255],
+        [192, 192, 192],
+      ],
+      [
+        [102, 178, 255],
+        [192, 192, 192],
+      ],
+      [
+        [51, 153, 255],
+        [192, 192, 192],
+      ],
+      [
+        [0, 128, 255],
+        [192, 192, 192],
+      ],
+      [
+        [0, 102, 204],
+        [192, 192, 192],
+      ],
+      [
+        [0, 76, 153],
+        [192, 192, 192],
+      ],
+      [
+        [0, 0, 153],
+        [192, 192, 192],
+      ],
+      [
+        [0, 0, 204],
+        [192, 192, 192],
+      ],
+      [
+        [0, 0, 225],
+        [192, 192, 192],
+      ],
+      [
+        [51, 51, 255],
+        [192, 192, 192],
+      ],
+      [
+        [204, 229, 255],
+        [192, 192, 192],
+      ],
+    ],
     minions: _.map(
       [
         {
           name: "Able",
           character: "!LOC:Armor",
-          color: [
-            [204, 255, 255],
-            [192, 192, 192],
-          ],
           personality: {
             percent_vehicle: 1,
             percent_bot: 0,
@@ -164,10 +230,6 @@ define(function () {
         {
           name: "AceAI",
           character: "!LOC:Roboticist",
-          color: [
-            [153, 255, 255],
-            [192, 192, 192],
-          ],
           personality: {
             percent_vehicle: 0,
             percent_bot: 1,
@@ -179,10 +241,6 @@ define(function () {
         {
           name: "Alpha",
           character: "!LOC:Uber",
-          color: [
-            [102, 255, 255],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.72,
             metal_demand_check: 0.8,
@@ -196,10 +254,6 @@ define(function () {
         {
           name: "Aryst0krat",
           character: "!LOC:Platinum",
-          color: [
-            [0, 255, 255],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.77,
             metal_demand_check: 0.85,
@@ -215,10 +269,6 @@ define(function () {
         {
           name: "Chronoblip",
           character: "!LOC:Gold",
-          color: [
-            [0, 204, 204],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.77,
             metal_demand_check: 0.85,
@@ -234,10 +284,6 @@ define(function () {
         {
           name: "Mjon",
           character: "!LOC:Defender",
-          color: [
-            [0, 153, 153],
-            [192, 192, 192],
-          ],
           econ_rate: 1,
           personality: {
             metal_drain_check: 0.71,
@@ -251,10 +297,6 @@ define(function () {
         {
           name: "Delta",
           character: "!LOC:Luddite",
-          color: [
-            [153, 204, 255],
-            [192, 192, 192],
-          ],
           personality: {
             basic_to_advanced_factory_ratio: 10,
           },
@@ -263,10 +305,6 @@ define(function () {
         {
           name: "Enzomatrix",
           character: "!LOC:Technologist",
-          color: [
-            [102, 178, 255],
-            [192, 192, 192],
-          ],
           personality: {
             adv_eco_mod: 0.5,
             adv_eco_mod_alone: 0.5,
@@ -280,10 +318,6 @@ define(function () {
         {
           name: "Fiveleafclover",
           character: "!LOC:Cautious",
-          color: [
-            [51, 153, 255],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 0.75,
             min_basic_fabbers: 4,
@@ -294,10 +328,6 @@ define(function () {
         {
           name: "Gamma",
           character: "!LOC:Aggressive",
-          color: [
-            [0, 128, 255],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 2,
             min_advanced_fabbers: 1,
@@ -307,10 +337,6 @@ define(function () {
         {
           name: "Gnugfur",
           character: "!LOC:Rush",
-          color: [
-            [0, 102, 204],
-            [192, 192, 192],
-          ],
           econ_rate: 1,
           personality: {
             neural_data_mod: 1.5,
@@ -323,10 +349,6 @@ define(function () {
         {
           name: "Nemicus",
           character: "!LOC:Turtle",
-          color: [
-            [0, 76, 153],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 0.5,
             adv_eco_mod: 0.5,
@@ -342,10 +364,6 @@ define(function () {
         {
           name: "Kapowaz",
           character: "!LOC:Original",
-          color: [
-            [0, 0, 153],
-            [192, 192, 192],
-          ],
           personality: {
             percent_vehicle: 0.275,
             percent_bot: 0.275,
@@ -365,10 +383,6 @@ define(function () {
         {
           name: "JT100010117",
           character: "!LOC:Absurd",
-          color: [
-            [0, 0, 204],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.65,
             metal_demand_check: 0.71,
@@ -380,10 +394,6 @@ define(function () {
         {
           name: "Kevin4001",
           character: "!LOC:Relentless",
-          color: [
-            [0, 0, 225],
-            [192, 192, 192],
-          ],
           personality: {
             metal_drain_check: 0.44,
             energy_drain_check: 0.55,
@@ -399,10 +409,6 @@ define(function () {
         {
           name: "Mostlikely",
           character: "!LOC:Swarm",
-          color: [
-            [51, 51, 255],
-            [192, 192, 192],
-          ],
           personality: {
             metal_demand_check: 0.99,
             energy_demand_check: 0.99,
@@ -415,10 +421,6 @@ define(function () {
         {
           name: "Nagasher",
           character: "!LOC:Economist",
-          color: [
-            [204, 229, 255],
-            [192, 192, 192],
-          ],
           personality: {
             metal_drain_check: 0.71,
             energy_drain_check: 0.8,

--- a/ui/main/game/galactic_war/shared/js/gw_faction_1.js
+++ b/ui/main/game/galactic_war/shared/js/gw_faction_1.js
@@ -159,15 +159,81 @@ define(function () {
         },
       },
     ],
+    minion_colors: [
+      [
+        [229, 204, 255],
+        [192, 192, 192],
+      ],
+      [
+        [204, 153, 255],
+        [192, 192, 192],
+      ],
+      [
+        [178, 102, 255],
+        [192, 192, 192],
+      ],
+      [
+        [153, 51, 255],
+        [192, 192, 192],
+      ],
+      [
+        [127, 0, 255],
+        [192, 192, 192],
+      ],
+      [
+        [102, 0, 204],
+        [192, 192, 192],
+      ],
+      [
+        [76, 0, 153],
+        [192, 192, 192],
+      ],
+      [
+        [255, 204, 255],
+        [192, 192, 192],
+      ],
+      [
+        [255, 153, 255],
+        [192, 192, 192],
+      ],
+      [
+        [255, 102, 255],
+        [192, 192, 192],
+      ],
+      [
+        [255, 0, 255],
+        [192, 192, 192],
+      ],
+      [
+        [204, 0, 204],
+        [192, 192, 192],
+      ],
+      [
+        [153, 0, 153],
+        [192, 192, 192],
+      ],
+      [
+        [255, 204, 229],
+        [192, 192, 192],
+      ],
+      [
+        [255, 153, 204],
+        [192, 192, 192],
+      ],
+      [
+        [255, 102, 178],
+        [192, 192, 192],
+      ],
+      [
+        [255, 51, 153],
+        [192, 192, 192],
+      ],
+    ],
     minions: _.map(
       [
         {
           name: "Progenitor",
           character: "!LOC:Air Force",
-          color: [
-            [229, 204, 255],
-            [192, 192, 192],
-          ],
           personality: {
             percent_land: 0,
             percent_air: 1,
@@ -180,10 +246,6 @@ define(function () {
         {
           name: "Sangudo",
           character: "!LOC:Navy",
-          color: [
-            [204, 153, 255],
-            [192, 192, 192],
-          ],
           personality: {
             percent_land: 0,
             percent_air: 0,
@@ -196,10 +258,6 @@ define(function () {
         {
           name: "Seniorhelix",
           character: "!LOC:Uber",
-          color: [
-            [178, 102, 255],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.72,
             metal_demand_check: 0.8,
@@ -214,10 +272,6 @@ define(function () {
         {
           name: "Stelarch",
           character: "!LOC:Platinum",
-          color: [
-            [153, 51, 255],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.77,
             metal_demand_check: 0.85,
@@ -233,10 +287,6 @@ define(function () {
         {
           name: "TheChessKnight",
           character: "!LOC:Gold",
-          color: [
-            [127, 0, 255],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.77,
             metal_demand_check: 0.85,
@@ -253,10 +303,6 @@ define(function () {
         {
           name: "Theta",
           character: "!LOC:Defender",
-          color: [
-            [102, 0, 204],
-            [192, 192, 192],
-          ],
           personality: {
             metal_drain_check: 0.71,
             energy_drain_check: 0.8,
@@ -270,10 +316,6 @@ define(function () {
         {
           name: "ToddFather",
           character: "!LOC:Luddite",
-          color: [
-            [76, 0, 153],
-            [192, 192, 192],
-          ],
           personality: {
             basic_to_advanced_factory_ratio: 10,
           },
@@ -283,10 +325,6 @@ define(function () {
         {
           name: "Ajax",
           character: "!LOC:Technologist",
-          color: [
-            [255, 204, 255],
-            [192, 192, 192],
-          ],
           personality: {
             adv_eco_mod: 0.5,
             adv_eco_mod_alone: 0.5,
@@ -299,10 +337,6 @@ define(function () {
         {
           name: "Armalisk",
           character: "!LOC:Cautious",
-          color: [
-            [255, 153, 255],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 0.75,
             min_basic_fabbers: 4,
@@ -312,10 +346,6 @@ define(function () {
         {
           name: "Calyx",
           character: "!LOC:Aggressive",
-          color: [
-            [255, 102, 255],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 2,
             min_advanced_fabbers: 1,
@@ -325,10 +355,6 @@ define(function () {
         {
           name: "Gambitdfa",
           character: "!LOC:Rush",
-          color: [
-            [255, 0, 255],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 1.5,
             adv_eco_mod: 2,
@@ -339,10 +365,6 @@ define(function () {
         {
           name: "Berlinetta",
           character: "!LOC:Turtle",
-          color: [
-            [204, 0, 204],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 0.5,
             adv_eco_mod: 0.5,
@@ -359,10 +381,6 @@ define(function () {
         {
           name: "Osiris",
           character: "!LOC:Original",
-          color: [
-            [153, 0, 153],
-            [192, 192, 192],
-          ],
           personality: {
             percent_vehicle: 0.025,
             percent_bot: 0.025,
@@ -381,10 +399,6 @@ define(function () {
         {
           name: "Tykus24",
           character: "!LOC:Absurd",
-          color: [
-            [255, 204, 229],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.65,
             metal_demand_check: 0.71,
@@ -395,10 +409,6 @@ define(function () {
         {
           name: "Vidicarus",
           character: "!LOC:Relentless",
-          color: [
-            [255, 153, 204],
-            [192, 192, 192],
-          ],
           personality: {
             metal_drain_check: 0.44,
             energy_drain_check: 0.55,
@@ -414,10 +424,6 @@ define(function () {
         {
           name: "Visionik",
           character: "!LOC:Swarm",
-          color: [
-            [255, 102, 178],
-            [192, 192, 192],
-          ],
           personality: {
             metal_demand_check: 0.99,
             energy_demand_check: 0.99,
@@ -430,10 +436,6 @@ define(function () {
         {
           name: "Commandonut",
           character: "!LOC:Economist",
-          color: [
-            [255, 51, 153],
-            [192, 192, 192],
-          ],
           personality: {
             metal_drain_check: 0.71,
             energy_drain_check: 0.8,

--- a/ui/main/game/galactic_war/shared/js/gw_faction_2.js
+++ b/ui/main/game/galactic_war/shared/js/gw_faction_2.js
@@ -159,15 +159,81 @@ define(function () {
         },
       },
     ],
+    minion_colors: [
+      [
+        [229, 255, 204],
+        [192, 192, 192],
+      ],
+      [
+        [204, 255, 153],
+        [192, 192, 192],
+      ],
+      [
+        [178, 255, 102],
+        [192, 192, 192],
+      ],
+      [
+        [153, 255, 51],
+        [192, 192, 192],
+      ],
+      [
+        [128, 255, 0],
+        [192, 192, 192],
+      ],
+      [
+        [102, 204, 0],
+        [192, 192, 192],
+      ],
+      [
+        [76, 153, 0],
+        [192, 192, 192],
+      ],
+      [
+        [204, 255, 204],
+        [192, 192, 192],
+      ],
+      [
+        [153, 255, 153],
+        [192, 192, 192],
+      ],
+      [
+        [102, 255, 102],
+        [192, 192, 192],
+      ],
+      [
+        [0, 255, 0],
+        [192, 192, 192],
+      ],
+      [
+        [0, 204, 0],
+        [192, 192, 192],
+      ],
+      [
+        [0, 153, 0],
+        [192, 192, 192],
+      ],
+      [
+        [0, 102, 0],
+        [192, 192, 192],
+      ],
+      [
+        [0, 153, 76],
+        [192, 192, 192],
+      ],
+      [
+        [0, 204, 102],
+        [192, 192, 192],
+      ],
+      [
+        [0, 255, 128],
+        [192, 192, 192],
+      ],
+    ],
     minions: _.map(
       [
         {
           name: "Potbelly79",
           character: "!LOC:Grunt",
-          color: [
-            [229, 255, 204],
-            [192, 192, 192],
-          ],
           personality: {
             percent_vehicle: 0.4,
             percent_bot: 0.3,
@@ -181,10 +247,6 @@ define(function () {
         {
           name: "Raventhornn",
           character: "!LOC:Dragoon",
-          color: [
-            [204, 255, 153],
-            [192, 192, 192],
-          ],
           personality: {
             percent_vehicle: 0,
             percent_bot: 0.2,
@@ -198,10 +260,6 @@ define(function () {
         {
           name: "SacrificialLamb",
           character: "!LOC:Uber",
-          color: [
-            [178, 255, 102],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.72,
             metal_demand_check: 0.8,
@@ -217,10 +275,6 @@ define(function () {
         {
           name: "Shadowdaemon",
           character: "!LOC:Platinum",
-          color: [
-            [153, 255, 51],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.77,
             metal_demand_check: 0.85,
@@ -237,10 +291,6 @@ define(function () {
         {
           name: "Spartandano",
           character: "!LOC:Gold",
-          color: [
-            [128, 255, 0],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.77,
             metal_demand_check: 0.85,
@@ -257,10 +307,6 @@ define(function () {
         {
           name: "Xenosentry",
           character: "!LOC:Defender",
-          color: [
-            [102, 204, 0],
-            [192, 192, 192],
-          ],
           personality: {
             metal_drain_check: 0.71,
             energy_drain_check: 0.8,
@@ -275,10 +321,6 @@ define(function () {
         {
           name: "TheFlax",
           character: "!LOC:Luddite",
-          color: [
-            [76, 153, 0],
-            [192, 192, 192],
-          ],
           personality: {
             basic_to_advanced_factory_ratio: 10,
           },
@@ -287,10 +329,6 @@ define(function () {
         {
           name: "Tokamaktech",
           character: "!LOC:Technologist",
-          color: [
-            [204, 255, 204],
-            [192, 192, 192],
-          ],
           personality: {
             adv_eco_mod: 0.5,
             adv_eco_mod_alone: 0.5,
@@ -304,10 +342,6 @@ define(function () {
         {
           name: "Twoboots",
           character: "!LOC:Cautious",
-          color: [
-            [153, 255, 153],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 0.75,
             min_basic_fabbers: 4,
@@ -317,10 +351,6 @@ define(function () {
         {
           name: "XenosentryPrime",
           character: "!LOC:Aggressive",
-          color: [
-            [102, 255, 102],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 2,
             min_advanced_fabbers: 1,
@@ -331,10 +361,6 @@ define(function () {
         {
           name: "Xinthar",
           character: "!LOC:Rush",
-          color: [
-            [0, 255, 0],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 1.5,
             adv_eco_mod: 2,
@@ -345,10 +371,6 @@ define(function () {
         {
           name: "Beast",
           character: "!LOC:Turtle",
-          color: [
-            [0, 204, 0],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 0.5,
             adv_eco_mod: 0.5,
@@ -364,10 +386,6 @@ define(function () {
         {
           name: "Beniesk",
           character: "!LOC:Original",
-          color: [
-            [0, 153, 0],
-            [192, 192, 192],
-          ],
           personality: {
             percent_vehicle: 0.15,
             percent_bot: 0.15,
@@ -381,10 +399,6 @@ define(function () {
         {
           name: "Locust",
           character: "!LOC:Absurd",
-          color: [
-            [0, 102, 0],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.65,
             metal_demand_check: 0.71,
@@ -394,10 +408,6 @@ define(function () {
         {
           name: "Zancrowe",
           character: "!LOC:Relentless",
-          color: [
-            [0, 153, 76],
-            [192, 192, 192],
-          ],
           personality: {
             metal_drain_check: 0.44,
             energy_drain_check: 0.55,
@@ -412,10 +422,6 @@ define(function () {
         {
           name: "Damubbster",
           character: "!LOC:Swarm",
-          color: [
-            [0, 204, 102],
-            [192, 192, 192],
-          ],
           personality: {
             metal_demand_check: 0.99,
             energy_demand_check: 0.99,
@@ -428,10 +434,6 @@ define(function () {
         {
           name: "Raizell",
           character: "!LOC:Economist",
-          color: [
-            [0, 255, 128],
-            [192, 192, 192],
-          ],
           personality: {
             metal_drain_check: 0.71,
             energy_drain_check: 0.8,

--- a/ui/main/game/galactic_war/shared/js/gw_faction_3.js
+++ b/ui/main/game/galactic_war/shared/js/gw_faction_3.js
@@ -159,15 +159,81 @@ define(function () {
         },
       },
     ],
+    minion_colors: [
+      [
+        [255, 204, 204],
+        [192, 192, 192],
+      ],
+      [
+        [255, 153, 153],
+        [192, 192, 192],
+      ],
+      [
+        [255, 102, 102],
+        [192, 192, 192],
+      ],
+      [
+        [255, 0, 0],
+        [192, 192, 192],
+      ],
+      [
+        [204, 0, 0],
+        [192, 192, 192],
+      ],
+      [
+        [153, 0, 0],
+        [192, 192, 192],
+      ],
+      [
+        [255, 204, 153],
+        [192, 192, 192],
+      ],
+      [
+        [255, 178, 102],
+        [192, 192, 192],
+      ],
+      [
+        [255, 153, 51],
+        [192, 192, 192],
+      ],
+      [
+        [255, 128, 0],
+        [192, 192, 192],
+      ],
+      [
+        [204, 102, 0],
+        [192, 192, 192],
+      ],
+      [
+        [255, 255, 204],
+        [192, 192, 192],
+      ],
+      [
+        [255, 255, 153],
+        [192, 192, 192],
+      ],
+      [
+        [255, 255, 102],
+        [192, 192, 192],
+      ],
+      [
+        [255, 255, 0],
+        [192, 192, 192],
+      ],
+      [
+        [204, 204, 0],
+        [192, 192, 192],
+      ],
+      [
+        [153, 153, 0],
+        [192, 192, 192],
+      ],
+    ],
     minions: _.map(
       [
         {
           name: "Betadyne",
           character: "!LOC:Space Invader",
-          color: [
-            [255, 204, 204],
-            [192, 192, 192],
-          ],
           personality: {
             percent_vehicle: 0,
             percent_bot: 0,
@@ -181,10 +247,6 @@ define(function () {
         {
           name: "Centurion",
           character: "!LOC:Astronaut",
-          color: [
-            [255, 153, 153],
-            [192, 192, 192],
-          ],
           personality: {
             percent_land: 0,
             percent_air: 0.5,
@@ -197,10 +259,6 @@ define(function () {
         {
           name: "Diremachine",
           character: "!LOC:Uber",
-          color: [
-            [255, 102, 102],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.72,
             metal_demand_check: 0.8,
@@ -216,10 +274,6 @@ define(function () {
         {
           name: "Enderstryke71",
           character: "!LOC:Platinum",
-          color: [
-            [255, 0, 0],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.77,
             metal_demand_check: 0.85,
@@ -236,10 +290,6 @@ define(function () {
         {
           name: "Iwmiked",
           character: "!LOC:Gold",
-          color: [
-            [204, 0, 0],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.77,
             metal_demand_check: 0.85,
@@ -255,10 +305,6 @@ define(function () {
         {
           name: "Majuju",
           character: "!LOC:Defender",
-          color: [
-            [153, 0, 0],
-            [192, 192, 192],
-          ],
           personality: {
             metal_drain_check: 0.71,
             energy_drain_check: 0.8,
@@ -272,10 +318,6 @@ define(function () {
         {
           name: "Nefelpitou",
           character: "!LOC:Luddite",
-          color: [
-            [255, 204, 153],
-            [192, 192, 192],
-          ],
           personality: {
             basic_to_advanced_factory_ratio: 10,
           },
@@ -285,10 +327,6 @@ define(function () {
         {
           name: "Invictus",
           character: "!LOC:Technologist",
-          color: [
-            [255, 178, 102],
-            [192, 192, 192],
-          ],
           personality: {
             adv_eco_mod: 0.5,
             adv_eco_mod_alone: 0.5,
@@ -302,10 +340,6 @@ define(function () {
         {
           name: "Rallus",
           character: "!LOC:Cautious",
-          color: [
-            [255, 153, 51],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 0.75,
             min_basic_fabbers: 4,
@@ -315,10 +349,6 @@ define(function () {
         {
           name: "Stickman9000",
           character: "!LOC:Aggressive",
-          color: [
-            [255, 128, 0],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 2,
             min_advanced_fabbers: 1,
@@ -329,10 +359,6 @@ define(function () {
         {
           name: "Zaazzaa",
           character: "!LOC:Rush",
-          color: [
-            [204, 102, 0],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 1.5,
             adv_eco_mod: 2,
@@ -343,10 +369,6 @@ define(function () {
         {
           name: "Aeson",
           character: "!LOC:Turtle",
-          color: [
-            [255, 255, 204],
-            [192, 192, 192],
-          ],
           personality: {
             neural_data_mod: 0.5,
             adv_eco_mod: 0.5,
@@ -362,10 +384,6 @@ define(function () {
         {
           name: "Banditks",
           character: "!LOC:Original",
-          color: [
-            [255, 255, 153],
-            [192, 192, 192],
-          ],
           personality: {
             percent_vehicle: 0.075,
             percent_bot: 0.075,
@@ -380,10 +398,6 @@ define(function () {
         {
           name: "SPZ58624",
           character: "!LOC:Absurd",
-          color: [
-            [255, 255, 102],
-            [192, 192, 192],
-          ],
           personality: {
             energy_drain_check: 0.65,
             metal_demand_check: 0.71,
@@ -394,10 +408,6 @@ define(function () {
         {
           name: "XOV",
           character: "!LOC:Relentless",
-          color: [
-            [255, 255, 0],
-            [192, 192, 192],
-          ],
           personality: {
             metal_drain_check: 0.44,
             energy_drain_check: 0.55,
@@ -412,10 +422,6 @@ define(function () {
         {
           name: "Reaver",
           character: "!LOC:Swarm",
-          color: [
-            [204, 204, 0],
-            [192, 192, 192],
-          ],
           personality: {
             metal_demand_check: 0.99,
             energy_demand_check: 0.99,
@@ -427,10 +433,6 @@ define(function () {
         {
           name: "Sadiga",
           character: "!LOC:Economist",
-          color: [
-            [153, 153, 0],
-            [192, 192, 192],
-          ],
           personality: {
             metal_drain_check: 0.71,
             energy_drain_check: 0.8,

--- a/ui/mods/com.pa.quitch.gwaioverhaul/faction/cluster_faction.js
+++ b/ui/mods/com.pa.quitch.gwaioverhaul/faction/cluster_faction.js
@@ -106,15 +106,125 @@ define([
         },
       },
     ],
+    minion_colors: [
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [142, 107, 68],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+      [
+        [70, 70, 70],
+        [192, 192, 192],
+      ],
+    ],
     minions: _.map(
       [
         {
           name: "Worker",
           character: "!LOC:Uber",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             energy_drain_check: 0.72,
@@ -127,10 +237,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Platinum",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             energy_drain_check: 0.77,
@@ -147,10 +253,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Gold",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             energy_drain_check: 0.77,
@@ -165,10 +267,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Defender",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             metal_drain_check: 0.71,
@@ -182,10 +280,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Luddite",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             basic_to_advanced_factory_ratio: 10,
@@ -195,10 +289,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Technologist",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             adv_eco_mod: 0.5,
@@ -212,10 +302,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Cautious",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             neural_data_mod: 0.75,
@@ -226,10 +312,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Aggressive",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             neural_data_mod: 2,
@@ -240,10 +322,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Rush",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             neural_data_mod: 1.5,
@@ -255,10 +333,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Turtle",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             neural_data_mod: 0.5,
@@ -275,10 +349,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Absurd",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             adv_eco_mod: 1.3,
@@ -290,10 +360,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Relentless",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             metal_drain_check: 0.44,
@@ -311,10 +377,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Swarm",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             metal_demand_check: 0.99,
@@ -325,10 +387,6 @@ define([
         {
           name: "Worker",
           character: "!LOC:Economist",
-          color: [
-            [142, 107, 68],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             metal_drain_check: 0.71,
@@ -342,10 +400,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Uber",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             energy_drain_check: 0.72,
@@ -358,10 +412,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Platinum",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             energy_drain_check: 0.77,
@@ -378,10 +428,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Gold",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             energy_drain_check: 0.77,
@@ -396,10 +442,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Defender",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             metal_drain_check: 0.71,
@@ -413,10 +455,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Luddite",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             basic_to_advanced_factory_ratio: 10,
@@ -426,10 +464,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Technologist",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             adv_eco_mod: 0.5,
@@ -442,10 +476,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Cautious",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             neural_data_mod: 0.75,
@@ -456,10 +486,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Aggressive",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             neural_data_mod: 2,
@@ -469,10 +495,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Rush",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             neural_data_mod: 1.5,
@@ -484,10 +506,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Turtle",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             neural_data_mod: 0.5,
@@ -504,10 +522,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Absurd",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             adv_eco_mod: 1.3,
@@ -519,10 +533,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Relentless",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             metal_drain_check: 0.44,
@@ -540,10 +550,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Swarm",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             metal_demand_check: 0.99,
@@ -554,10 +560,6 @@ define([
         {
           name: "Security",
           character: "!LOC:Economist",
-          color: [
-            [70, 70, 70],
-            [192, 192, 192],
-          ],
           isCluster: true,
           personality: {
             metal_drain_check: 0.71,

--- a/ui/mods/com.pa.quitch.gwaioverhaul/gw_play/cards.js
+++ b/ui/mods/com.pa.quitch.gwaioverhaul/gw_play/cards.js
@@ -169,14 +169,15 @@ if (!gwaioCardsLoaded) {
               !inventory.cards()[0].minions
             ) {
               var playerFaction = inventory.getTag("global", "playerFaction");
-              _.times(2, function () {
+              for(var i = 0; i < 2; i++) {
                 var subcommander = _.sample(GWFactions[playerFaction].minions);
+                subcommander["color"] = GWFactions[playerFaction].minion_colors[i];
                 inventory.cards().push({
                   id: "gwc_minion",
                   minion: subcommander,
                   unique: Math.random(),
                 });
-              });
+              }
               inventory.applyCards();
               model.driveAccessInProgress(true);
               GW.manifest.saveGame(game).then(function () {
@@ -570,6 +571,7 @@ if (!gwaioCardsLoaded) {
                       product.minion = _.sample(
                         GWFactions[playerFaction].minions
                       );
+                      product.minion["color"] = GWFactions[playerFaction].minion_colors[game.inventory().cards()[0].minions];
                       product.unique = Math.random();
                     });
                   } else if (product.id === "gwc_add_card_slot") {


### PR DESCRIPTION
Allows for colours to be based on the number of minions/sub-commanders which are held in a player's or AI's deck. Therefore allowing colours to be prioritised to offer more contrasting variations of a faction's base colour.

- Colours have not been checked. They are currently based on the order of the minions array.